### PR TITLE
use file_content to generate md5 instead of filename

### DIFF
--- a/Components/MjmlCompiler.php
+++ b/Components/MjmlCompiler.php
@@ -49,7 +49,7 @@ class MjmlCompiler implements MjmlCompilerInterface
      */
     public function compile(string $file): string
     {
-        $cacheKey = 'mjml' . md5($file);
+        $cacheKey = 'mjml' . md5_file($file);
 
         if ($content = $this->cache->load($cacheKey)) {
             return $content;

--- a/Components/WebMjmlCompiler.php
+++ b/Components/WebMjmlCompiler.php
@@ -45,14 +45,15 @@ class WebMjmlCompiler implements MjmlCompilerInterface
      */
     public function compile(string $file): string
     {
-        $cacheKey = 'mjml' . md5($file);
+
+        $mjmlContent = file_get_contents($file);
+
+        $cacheKey = 'mjml' . md5($mjmlContent);
 
         if ($content = $this->cache->load($cacheKey)) {
             return $content;
         }
-
-        $mjmlContent = file_get_contents($file);
-
+        
         $mjmlContent = $this->parseIncludes($mjmlContent, dirname($file));
 
         $response = $this->requestToApi($mjmlContent);


### PR DESCRIPTION
PRO: so you would be able to work with active cache
CON: affects file-read on storage